### PR TITLE
Fix autoPlay on web

### DIFF
--- a/src/Lottie.tsx
+++ b/src/Lottie.tsx
@@ -41,7 +41,7 @@ const LottieView = forwardRef<LottieViewRef, LottieViewProps>(
         lottieRef={lottieRef}
         animationData={source}
         loop={loop}
-        autoPlay={autoPlay}
+        autoplay={autoPlay}
         style={style as React.CSSProperties}
         onComplete={onAnimationFinish}
       />


### PR DESCRIPTION

## Summary

lottie-react has `autoplay` not `autoPlay` ( no capital P )

## Motivation

When running with RNW ( expo actually) `autoPlay = false`  wasn't  taken into account.

## Testing


- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
